### PR TITLE
Removed variable declaration inside a 'for loop'

### DIFF
--- a/miasm/analysis/taint.c
+++ b/miasm/analysis/taint.c
@@ -248,7 +248,8 @@ taint_get_memory(struct taint_colors_t *colors,
 void
 taint_remove_all_memory(struct taint_colors_t *colors)
 {
-    for (uint64_t i = 0; i < colors->nb_colors ; i++)
+    uint64_t i;
+    for (i = 0; i < colors->nb_colors ; i++)
         taint_color_remove_all_memory(colors, i);
 }
 
@@ -287,7 +288,8 @@ taint_init_callback_info(uint64_t nb_registers, uint32_t max_register_size)
 		exit(EXIT_FAILURE);
 	}
 
-    for( uint64_t index = 0; index < nb_registers; index ++)
+    uint64_t index = 0;
+    for( index = 0; index < nb_registers; index ++)
     {
         callback_info->last_tainted.registers[index] = calloc(1, sizeof(*callback_info->last_tainted.registers[index]));
     }
@@ -307,7 +309,7 @@ taint_init_callback_info(uint64_t nb_registers, uint32_t max_register_size)
 		exit(EXIT_FAILURE);
 	}
 
-    for( uint64_t index = 0; index < nb_registers; index ++)
+    for( index = 0; index < nb_registers; index ++)
     {
         callback_info->last_untainted.registers[index] = calloc(1, sizeof(*callback_info->last_untainted.registers[index])); 
     }
@@ -335,7 +337,8 @@ taint_clean_all_callback_info(struct taint_colors_t *colors)
 void
 taint_clean_callback_info(struct taint_colors_t *colors, uint64_t color_index)
 {
-	for(uint64_t i = 0; i < colors->nb_registers ; i++)
+	uint64_t i = 0; 
+	for( i = 0; i < colors->nb_registers ; i++)
 	{
         interval_tree_free(colors->colors[color_index].callback_info->last_tainted.registers[i]);
         //colors->colors[color_index].callback_info->last_tainted.registers[i] = calloc(1, sizeof(*colors->colors[color_index].callback_info->last_tainted.registers[i]));

--- a/miasm/jitter/interval_tree/interval_tree.c
+++ b/miasm/jitter/interval_tree/interval_tree.c
@@ -134,8 +134,8 @@ interval_tree_add_merged(struct rb_root *root,
                                                                struct interval))
 {
     struct interval_result sub = merge_function(a, b);
-
-    for(unsigned long index = 0; index < sub.nb_results; index++)
+    unsigned long index = 0;
+    for(index = 0; index < sub.nb_results; index++)
         interval_tree_insert_new_node(root,
                                       sub.intervals[index]);
 }


### PR DESCRIPTION
Older versions of gcc do not handle this mechanism.